### PR TITLE
sort by id as numeric rather than string

### DIFF
--- a/src/reducers/beers.js
+++ b/src/reducers/beers.js
@@ -7,8 +7,8 @@ reducers should do 3 things:
     3. Return the default state if no action is handled
 */
 const byId = (beer_a, beer_b) => {
-  if (beer_a.id < beer_b.id) return -1
-  if (beer_a.id > beer_b.id) return 1
+  if (Number(beerA.id) < Number(beerB.id)) return -1
+  if (Number(beerA.id) > Number(beerB.id)) return 1
   return 0
 }
 


### PR DESCRIPTION
`beer.id` is a string, so the results of sorting is somehow not intuitive. For example, 100 comes before 80.